### PR TITLE
Use correct field separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -6,16 +6,16 @@
 # Datatypes (KEYWORD1)
 #######################################
 
-BME280         KEYWORD1
+BME280	KEYWORD1
 
 #######################################
 # Methods and Functions (KEYWORD2)
 #######################################
 
-settings       KEYWORD2
-begin          KEYWORD2
-reset          KEYWORD2
-readPressure   KEYWORD2
-readAltitude   KEYWORD2
-readHumidity   KEYWORD2
-readTemp       KEYWORD2
+settings	KEYWORD2
+begin	KEYWORD2
+reset	KEYWORD2
+readPressure	KEYWORD2
+readAltitude	KEYWORD2
+readHumidity	KEYWORD2
+readTemp	KEYWORD2


### PR DESCRIPTION
The Arduino IDE requires the use of a single true tab separator between the keyword name and identifier. When spaces are used rather than a true tab the keyword is not highlighted.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords